### PR TITLE
don't prepend *compiler-path* to assembly name

### DIFF
--- a/Clojure/Clojure/CljCompiler/GenClass.cs
+++ b/Clojure/Clojure/CljCompiler/GenClass.cs
@@ -84,7 +84,7 @@ namespace clojure.lang
             string extension = hasMain ? ".exe" : ".dll";
 
             
-            GenContext context = GenContext.CreateWithExternalAssembly(Compiler.munge(path=="." ? className : path + "/" + className), extension, true);
+            GenContext context = GenContext.CreateWithExternalAssembly(Compiler.munge(className), extension, true);
 
             // define the class
             List<Type> interfaceTypes = new List<Type>();


### PR DESCRIPTION
The following console output illustrates the bug fixed in this commit:

```
    c:\github\VideoDump>(set CLOJURE_COMPILE_PATH=bin) & Clojure.Compile.exe program
    Compiling program to bin -- 366 milliseconds.

    c:\github\VideoDump>dir bin
     Volume in drive C has no label.
     Volume Serial Number is C201-2D30

     Directory of c:\github\VideoDump\bin

    06/20/2013  12:16 PM    <DIR>          .
    06/20/2013  12:16 PM    <DIR>          ..
    06/20/2013  11:58 AM             4,608 bin_SLASH_program.exe
    06/20/2013  11:58 PM             6,144 program.clj.dll
                   3 File(s)         15,360 bytes
                   2 Dir(s)  114,253,045,760 bytes free
```

`GenClass.GenerateClass` should not prepend the `*compiler-path*` to the
assembly name that is given to `GenContext.CreateWithExternalAssembly`;
the latter method already accounts for the `*compiler-path*` when
determining where to place the generated assembly.
