### PR TITLE
Modify .nuget/NuGet.targets to fix problem with nuget downloads under mo...

### DIFF
--- a/Clojure/.nuget/NuGet.targets
+++ b/Clojure/.nuget/NuGet.targets
@@ -35,7 +35,7 @@
    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
        <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
-       <PackagesConfig>packages.config</PackagesConfig>
+       <PackagesConfig>$(SolutionDir)packages.config</PackagesConfig>
        <PackagesDir>$(SolutionDir)packages</PackagesDir>
    </PropertyGroup>
    


### PR DESCRIPTION
...no and osx

Exec cmd (under xbuild@osx):
EnableNuGetPackageRestore=ture Runtime=MONO xbuild ClojureCLR.sln

Error message:
clojure-clr/Clojure/ClojureCLR.sln (default targets) ->
(Build target) ->
clojure-clr/Clojure/Clojure/Clojure.csproj (default targets) ->
clojure-clr/Clojure/.nuget/nuget.targets (RestorePackages target) ->

```
clojure-clr/Clojure/.nuget/nuget.targets: error : Command 'mono --runtime=v4.0.30319 clojure-clr/Clojure/.nuget/NuGet.exe install "packages.config" -source ""  -RequireConsent -o "clojure-clr/Clojure/packages"' exited with code: 1.
```

Reason:
different of position PakcageConfig.
