### PR TITLE
Use dlls over cljs when their timestamps are equal

### DIFF
--- a/Clojure/Clojure/Lib/RT.cs
+++ b/Clojure/Clojure/Lib/RT.cs
@@ -3311,7 +3311,7 @@ namespace clojure.lang
 
 
                 if ((assyInfo != null &&
-                     (cljInfo == null || assyInfo.LastWriteTime > cljInfo.LastWriteTime)))
+                     (cljInfo == null || assyInfo.LastWriteTime >= cljInfo.LastWriteTime)))
                 {
                     try
                     {


### PR DESCRIPTION
This case comes up when a project is e.g. cloned off a git repo and the DLLs and CLJ files get identical timestamps.
