### PR TITLE
Stop type lookups on lexically bound symbols

### DIFF
--- a/Clojure/Clojure/CljCompiler/Ast/HostExpr.cs
+++ b/Clojure/Clojure/CljCompiler/Ast/HostExpr.cs
@@ -281,6 +281,9 @@ namespace clojure.lang.CljCompiler.Ast
             if (form is Symbol)
             {
                 Symbol sym = (Symbol)form;
+                // if symbol refers to something in the lexical scope, it's not a type
+                if(Compiler.LocalEnvVar.deref() != null && ((IPersistentMap)Compiler.LocalEnvVar.deref()).containsKey(sym))
+                    return null;
                 if (sym.Namespace == null) // if ns-qualified, can't be classname
                 {
                     if (Util.equals(sym, Compiler.CompileStubSymVar.get()))
@@ -317,7 +320,7 @@ namespace clojure.lang.CljCompiler.Ast
 
         internal static Type TagToType(object tag)
         {
-            Type t = MaybeType(tag, true);
+            Type t = null;
 
             Symbol sym = tag as Symbol;
             if (sym != null)
@@ -395,6 +398,8 @@ namespace clojure.lang.CljCompiler.Ast
                 }
             }
 
+            if(t == null)
+                t = MaybeType(tag, true);
             if (t != null)
                 return t;
 


### PR DESCRIPTION
This is a port of @ztellman's pending patch http://dev.clojure.org/jira/browse/CLJ-1529

This patch avoids unnecessary lookups on symbols that are known to be lexically bound, resulting in significant speedup in many cases. Details are on the Jira page.

In the event of @ztellman's branch getting merged in to Clojure-JVM, merging this PR should reproduce its behavior.
