### PR TITLE
Fix build on Linux and OSX

### DIFF
--- a/Clojure/.nuget/NuGet.targets
+++ b/Clojure/.nuget/NuGet.targets
@@ -34,9 +34,9 @@
    
    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
        <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
-       <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
-       <PackagesConfig>packages.config</PackagesConfig>
-       <PackagesDir>$(SolutionDir)packages</PackagesDir>
+       <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir), ".nuget"))</NuGetToolsPath>
+       <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
+       <PackagesDir>$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
    </PropertyGroup>
    
    <PropertyGroup>

--- a/Clojure/Clojure.Tests/Clojure.Tests.csproj
+++ b/Clojure/Clojure.Tests/Clojure.Tests.csproj
@@ -345,7 +345,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Clojure/Clojure/Clojure.csproj
+++ b/Clojure/Clojure/Clojure.csproj
@@ -405,7 +405,7 @@
     <AssemblyOriginatorKeyFile>$(CLOJURE_SNK)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Clojure/Csharp.Tests/Csharp.Tests.csproj
+++ b/Clojure/Csharp.Tests/Csharp.Tests.csproj
@@ -140,7 +140,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Clojure/DlrConsole/DlrConsole.csproj
+++ b/Clojure/DlrConsole/DlrConsole.csproj
@@ -96,7 +96,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
There were 2 problems:
1. (Affected OSX and Linux) Wrong path to "packages.config". Xbuild tried to search it in SolutionDir, not in ProjectDir. 
2. (Affected Linux) Linux has case-sensitive file system, so xbuild couldn't start "nuget.exe"

Command for build with mono:
EnableNuGetPackageRestore=true MONO_IOMAP=all xbuild build.proj /target:Build /p:Configuration="Release 4.0" /p:Platform="Any CPU"