### PR TITLE
Replace slashes in InitClassName with dollar signs

### DIFF
--- a/Clojure/Clojure/CljCompiler/Compiler.cs
+++ b/Clojure/Clojure/CljCompiler/Compiler.cs
@@ -1465,7 +1465,7 @@ namespace clojure.lang
 
         internal static string InitClassName(string sourcePath)
         {
-            return "__Init__$" + sourcePath.Replace(".", "/");
+            return "__Init__$" + sourcePath.Replace(".", "/").Replace("/", "$");
         }
         
         public static void PushNS()


### PR DESCRIPTION
There seems to be a bug in Mono where types with slashes in their name are not findable by normal means. This patch changes the names generated by `InitClassName` to use `$` instead of `/`.