### PR TITLE
Fixing bug with stacktrace for missing methods

### DIFF
--- a/Clojure/Clojure.Source/clojure/main.clj
+++ b/Clojure/Clojure.Source/clojure/main.clj
@@ -56,13 +56,17 @@
 
 (defn stack-element-classname
   [^System.Diagnostics.StackFrame el]
-  (if-let [t (.. el  (GetMethod) ReflectedType)] 
-    (.FullName t) 
-	""))
+  (or (when-let [m (.. el  (GetMethod))]
+        (when-let [t (.ReflectedType m)]
+          (.FullName t)))
+      "<class unknown>"))
 
 (defn stack-element-methodname
   [^System.Diagnostics.StackFrame el]
-  (.. el (GetMethod)  Name))
+  (or (when-let [m (.GetMethod el)]
+        (.Name m))
+      "<method unknown>"))
+
 
 ;;;
 


### PR DESCRIPTION
The process of computing printouts for stacktraces in the REPL itself throws for certain Exceptions, in particular those with StackFrames with missing methods. This then kills the REPL.
```
(.adfadf :bla)
```
will kill the REPL, for example.
This can be fixed by checking if the method and class is actually there or not before computing the printout.