### PR TITLE
fixing bug with print repl failing for exception stackframes without …

### DIFF
--- a/Clojure/Clojure.Source/clojure/core_print.clj
+++ b/Clojure/Clojure.Source/clojure/core_print.clj
@@ -517,10 +517,15 @@
 (defn StackTraceElement->vec
   "Constructs a data representation for a StackTraceElement"
   {:added "1.9"}
-  [^System.Diagnostics.StackFrame o]                                                                                                 ;;; ^StackTraceElement
-  (if (nil? o)                                                                                                                       ;;; DM: added -- we don't get a stack trace unless actually thrown
-    nil                                                                                                                              ;;; DM: added
-   [(symbol (.FullName (.GetType o))) (symbol (.Name (.GetMethod o))) (.GetFileName o) (.GetFileLineNumber o)]))                     ;;; (.getClassName o)  (.getMethodName o) .getFileName .getLineNumber
+  [^System.Diagnostics.StackFrame o]
+  (if (nil? o)
+    nil
+    [(symbol (.FullName (.GetType o)))
+     (if-let [m (.GetMethod o)]
+       (symbol (.Name m))
+       "NO_METHOD")
+     (or (.GetFileName o) "NO_FILE")
+     (.GetFileLineNumber o)]))
 
 (defn Throwable->map
   "Constructs a data representation for a Throwable."

--- a/Clojure/Clojure.Source/clojure/main.clj
+++ b/Clojure/Clojure.Source/clojure/main.clj
@@ -56,17 +56,14 @@
 
 (defn stack-element-classname
   [^System.Diagnostics.StackFrame el]
-  (or (when-let [m (.. el  (GetMethod))]
-        (when-let [t (.ReflectedType m)]
-          (.FullName t)))
-      "<class unknown>"))
+  (if-let [t (some-> el (.GetMethod) (.ReflectedType))]
+    (.FullName t)
+    "NO_CLASS"))
 
 (defn stack-element-methodname
   [^System.Diagnostics.StackFrame el]
-  (or (when-let [m (.GetMethod el)]
-        (.Name m))
-      "<method unknown>"))
-
+  (or (some-> el (.GetMethod) (.Name))
+      "NO_METHOD"))
 
 ;;;
 


### PR DESCRIPTION
…class or method.

Specifically, in Arcadia it is sometimes the case that exceptions are thrown, some stackframes of which have null values for `.GetType` and `.GetMethod` (evaluating `(map (fn [a b] b) [1 2 3])` seems to cause this, for example). This breaks the exception handling machinery itself, which crashes the REPL.