### PR TITLE
Stop throwing exceptions on locals with primitive type hints

### DIFF
--- a/Clojure/Clojure/CljCompiler/Ast/LocalBinding.cs
+++ b/Clojure/Clojure/CljCompiler/Ast/LocalBinding.cs
@@ -59,9 +59,6 @@ namespace clojure.lang.CljCompiler.Ast
 
         public LocalBinding(int index, Symbol sym, Symbol tag, Expr init, Type declaredType, bool isThis, bool isArg, bool isByRef)
         {
-            if (Compiler.MaybePrimitiveType(init) != null && tag != null)
-                throw new InvalidOperationException("Can't type hint a local with a primitive initializer");
-
             Index = index;
             _sym = sym;
             Tag = tag;


### PR DESCRIPTION
There is no real reason for this exception and it makes high performance well typed code impossible to write.

I think this was fixed in the past but maybe regressed somehow?