### PR TITLE
Fix build on Mono

### DIFF
--- a/Clojure/Clojure.Compile/Clojure.Compile.csproj
+++ b/Clojure/Clojure.Compile/Clojure.Compile.csproj
@@ -155,12 +155,11 @@
   </Target>
   -->
   <PropertyGroup>
+    <ClojureLibraries>clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect clojure.edn</ClojureLibraries>
     <PostBuildEvent Condition=" '$(Runtime)' == 'Mono' ">CLOJURE_COMPILER_DIRECT_LINKING=$(DirectLinking)
-mono $(TargetPath) clojure.spec.gen clojure.spec.test clojure.spec clojure.core.specs</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(Runtime)' == 'Mono' ">CLOJURE_COMPILER_DIRECT_LINKING=$(DirectLinking)
-mono $(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect clojure.edn</PostBuildEvent>
+mono $(TargetPath) $(ClojureLibraries)</PostBuildEvent>
     <PostBuildEvent Condition=" '$(Runtime)' == '.Net' ">set clojure.compiler.direct-linking=$(DirectLinking)
-$(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect  clojure.edn</PostBuildEvent>
+$(TargetPath) $(ClojureLibraries)</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -169,8 +168,4 @@ $(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.co
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>set clojure.compiler.direct-linking=$(DirectLinking)
-$(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect  clojure.edn clojure.datafy</PostBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
A PostBuildEvent ran on Mono when it shouldn't, probably some merge mistake.
Also updated the list of libraries that are passed to the compiler.

With this fix I can build with Mono 6.0 on macOS using `msbuild /restore build.proj /p:Runtime=Mono`