### PR TITLE
Fix behaviour of "standard input" on Unix-like operating systems

### DIFF
--- a/Clojure/Clojure/Lib/RT.cs
+++ b/Clojure/Clojure/Lib/RT.cs
@@ -183,15 +183,15 @@ namespace clojure.lang
         #region Vars (I/O-related)
 
         public static readonly Var OutVar 
-            = Var.intern(ClojureNamespace, Symbol.intern("*out*"), System.Console.Out).setDynamic();
+            = Var.intern(ClojureNamespace, Symbol.intern("*out*"), new StreamWriter(System.Console.OpenStandardOutput())).setDynamic();
         
         public static readonly Var ErrVar
-            = Var.intern(ClojureNamespace, Symbol.intern("*err*"), System.Console.Error).setDynamic();
+            = Var.intern(ClojureNamespace, Symbol.intern("*err*"), new StreamWriter(System.Console.OpenStandardError())).setDynamic();
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public static readonly Var InVar =
             Var.intern(ClojureNamespace, Symbol.intern("*in*"),
-            new clojure.lang.LineNumberingTextReader(System.Console.In)).setDynamic();
+            new clojure.lang.LineNumberingTextReader(new StreamReader(System.Console.OpenStandardInput()))).setDynamic();
 
         static readonly Var PrintReadablyVar
             //= Var.intern(CLOJURE_NS, Symbol.intern("*print-readably*"), RT.T);


### PR DESCRIPTION
_**Edit:** I have signed the Clojure contributor license agreement, but I've just realised that the Clojure docs say to create a Jira ticket and upload a patch to it instead of creating a pull request; does ClojureCLR follow the same workflow?  I'm happy to do that if you'd prefer._

While experimenting with the .NET Core port of ClojureCLR, I noticed that on Linux (and likely also macOS), the REPL was unable to handle backspacing or the use of the cursor/arrow keys.

Here is a screencast of the bug.

![Screencast from 05-06-20 10 19 34](https://user-images.githubusercontent.com/26504626/83859983-9a6a5380-a716-11ea-9e3e-c96ad0812fea.gif)

After some experimentation, I found that the issue was with the implementation of `*in*`.  I managed to fix it by replacing [`Console.In`](https://docs.microsoft.com/en-us/dotnet/api/system.console.in) with [`Console.OpenStandardInput()`](https://docs.microsoft.com/en-us/dotnet/api/system.console.openstandardinput).  (I also updated the other two "[standard streams](https://en.wikipedia.org/wiki/Standard_streams)" so that they all work the same way.)

I have tested these changes on both Fedora Linux 32 and Microsoft Windows 10 with .NET Core 3.1.  According to the Microsoft Docs I linked above this change will work on all .NET Framework, .NET Standard and .NET Core versions.

_(Note: this pull request is set to merge to the `newframework` branch, as I believe this is only a bug on .NET Core.)_

If you would like me to make any changes to this pull request, I'm happy to do them, or if you want to make the changes yourself instead of merging this, that's fine with me too.

P.S. Thanks so much for all your work on this port, I'm really excited for the official .NET Core release of ClojureCLR (no matter how slow start-up has to be).