### PR TITLE
Added new .Net Core 3 and .Net 5 tasks

### DIFF
--- a/Clojure/build.proj
+++ b/Clojure/build.proj
@@ -195,6 +195,55 @@
     <Copy SourceFiles="@(Dlls)" DestinationFolder="..\dist\$(Configuration)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(CljFiles)" DestinationFolder="..\dist\$(Configuration)\clojure\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
+	
+  <!-- RJ: New build and clean targets for .Net Core 3.X and .Net 5-->
+  <Target Name="BuildD3">
+    <Exec Command="dotnet build Clojure.sln -c Debug -p:Platform=&quot;Any CPU&quot; -f netcoreapp3.1 -o clojure-clr-debug3" 
+          WorkingDirectory="$(OutputPath)" />
+  </Target>
+
+  <Target Name="BuildR3">
+    <Exec Command="dotnet build Clojure.sln -c Release -p:Platform=&quot;Any CPU&quot; -f netcoreapp3.1 -o clojure-clr-release3" 
+          WorkingDirectory="$(OutputPath)" />
+  </Target>
+
+  <Target Name="BuildD5">
+    <Exec Command="dotnet build Clojure.sln -c Debug -p:Platform=&quot;Any CPU&quot; -f net5.0 -o clojure-clr-debug5" 
+          WorkingDirectory="$(OutputPath)" />
+  </Target>
+
+  <Target Name="BuildR5">
+    <Exec Command="dotnet build Clojure.sln -c Release -p:Platform=&quot;Any CPU&quot; -f net5.0 -o clojure-clr-release5" 
+          WorkingDirectory="$(OutputPath)" />
+  </Target>
+
+  <Target Name="CleanD3">
+    <Exec Command="dotnet clean Clojure.sln -p:Platform=&quot;Any CPU&quot; -o clojure-clr-debug3" 
+          WorkingDirectory="$(OutputPath)" />
+    <RemoveDir
+          Directories="clojure-clr-debug3" />
+  </Target>
+
+  <Target Name="CleanR3">
+    <Exec Command="dotnet clean Clojure.sln -p:Platform=&quot;Any CPU&quot; -o clojure-clr-release3" 
+          WorkingDirectory="$(OutputPath)" />
+    <RemoveDir
+          Directories="clojure-clr-release3" />
+  </Target>
+
+  <Target Name="CleanD5">
+    <Exec Command="dotnet clean Clojure.sln -p:Platform=&quot;Any CPU&quot; -o clojure-clr-debug5" 
+          WorkingDirectory="$(OutputPath)" />
+    <RemoveDir
+          Directories="clojure-clr-debug5" />
+  </Target>
+
+  <Target Name="CleanR5">
+    <Exec Command="dotnet clean Clojure.sln -p:Platform=&quot;Any CPU&quot; -o clojure-clr-release5" 
+          WorkingDirectory="$(OutputPath)" />
+    <RemoveDir
+          Directories="clojure-clr-release5" />
+  </Target>
   
 
 


### PR DESCRIPTION
Added new .Net Core 3 and .Net 5 build and clean tasks
Cross walk:
- BuildD3 => "Build Debug for .Net Core 3.x"
- BuildR3 => "Build Release for .Net Core 3.x"
- CleanD3 => "Clean .Net Core 3.x build directory"
- BuildD5 => "Build Debug for .Net 5.x"
- BuildR5 => "Build Release for .Net 5.x"
- CleanD5 => "Clean .Net Core 5.x build directory"

=============================================
build commands
----------------------
dotnet msbuild build.proj -t:BuildD3 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:BuildR3 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:BuildD5 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:BuildR5 -p:Platform="Any CPU"
==============================================
Clean commands
------------------------
dotnet msbuild build.proj -t:CleanD3 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:CleanR3 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:CleanD5 -p:Platform="Any CPU"

dotnet msbuild build.proj -t:CleanR5 -p:Platform="Any CPU"