### PR TITLE
Changed "Tragets" to "targets"

### DIFF
--- a/Clojure/build.proj
+++ b/Clojure/build.proj
@@ -28,7 +28,7 @@
     <PublicKey>$(ClojureCLRBuildDir)\Key.snk</PublicKey>
   </PropertyGroup>
 
-  <Import Project="$(BuildSysDir)\Tasks.Targets" />
+  <Import Project="$(BuildSysDir)\Tasks.targets" />
   <Import Project="$(RootDir)CurrentVersion.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
Changed "Task.Targets" to "Task.targets" because the build was failing on Linux due to case sensitivity in naming.