### PR TITLE
Added net5.0 target to support .Net 5 builds

### DIFF
--- a/Clojure/Clojure.Main/Clojure.Main.csproj
+++ b/Clojure/Clojure.Main/Clojure.Main.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <StartupObject>Clojure.CljMain</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
This change corresponds to a previous pull request for changes to  build.proj. The change will allow ClojureCLR to be built with the "dotnet" command-line tool.