### PR TITLE
Added netcoreapp3.1 and net5.0 targets

### DIFF
--- a/Clojure/Clojure.Source/Clojure.Source.csproj
+++ b/Clojure/Clojure.Source/Clojure.Source.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <RootNamespace>clojure.lang</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>


### PR DESCRIPTION
Added netcoreapp3.1 and net5.0 targets to support .Net 3.1 and .Net 5 builds. This change corresponds to a previous pull request for changes to  build.proj. The change will allow ClojureCLR to be built with the "dotnet" command-line tool.