### PR TITLE
Added net5.0 target to support .Net 5 builds

### DIFF
--- a/Clojure/Csharp.Tests/Csharp.Tests.csproj
+++ b/Clojure/Csharp.Tests/Csharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change corresponds to a previous pull request for changes to  build.proj. The change will allow ClojureCLR to be built with the "dotnet" command-line tool.