### PR TITLE
Build with latest dotnet SDK/mono on *nix

### DIFF
--- a/Clojure/Clojure.Compile/Clojure.Compile.csproj
+++ b/Clojure/Clojure.Compile/Clojure.Compile.csproj
@@ -24,7 +24,11 @@
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(TargetFramework)' == 'net461'">
     <Exec Command="$(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect  clojure.edn clojure.datafy" WorkingDirectory="$(OutDir)" />
-    <Exec Command="xcopy $(ProjectDir)$(OutDir)clojure*.dll $(SolutionDir)Clojure.Main461\$(OutDir)  /i /s /e /y" />
+    <ItemGroup>
+      <CljCoreBin Include="$(ProjectDir)$(OutDir)clojure*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CljCoreBin)"
+      DestinationFolder="$(SolutionDir)Clojure.Main461\$(OutDir)" />
   </Target>
   
 

--- a/Clojure/Clojure.Compile/Clojure.Compile.csproj
+++ b/Clojure/Clojure.Compile/Clojure.Compile.csproj
@@ -23,7 +23,11 @@
 
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(TargetFramework)' == 'net461'">
-    <Exec Command="$(TargetPath) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect  clojure.edn clojure.datafy" WorkingDirectory="$(OutDir)" />
+    <PropertyGroup>
+      <TargetCmdline Condition=" $(TargetCmdline) == '' ">$(TargetPath)</TargetCmdline>
+      <TargetCmdline Condition=" '$(OS)' == 'Unix' ">mono $(TargetPath)</TargetCmdline>
+    </PropertyGroup>
+    <Exec Command="$(TargetCmdline) clojure.core clojure.core.protocols clojure.core.server clojure.core.reducers clojure.main clojure.set clojure.zip  clojure.walk clojure.stacktrace clojure.template clojure.test clojure.test.tap clojure.test.junit clojure.pprint clojure.clr.io clojure.repl clojure.clr.shell clojure.string clojure.data clojure.reflect  clojure.edn clojure.datafy" WorkingDirectory="$(OutDir)" />
     <ItemGroup>
       <CljCoreBin Include="$(ProjectDir)$(OutDir)clojure*.dll" />
     </ItemGroup>

--- a/Clojure/build.proj
+++ b/Clojure/build.proj
@@ -39,6 +39,7 @@
 	<ClojureMainBinDir Condition=" '$(TestTargetFramework)' != 'net461' ">$(RootDir)Clojure.Main\bin\$(Configuration)\$(TestTargetFramework)</ClojureMainBinDir>
     <clji Condition=" '$(TestTargetFramework)' == 'net461' ">Clojure.Main461.exe</clji>
     <clji Condition=" '$(TestTargetFramework)' != 'net461' ">Clojure.Main.exe</clji>		
+    <clji Condition=" '$(TestTargetFramework)' != 'net461' And '$(MSBuildRuntimeType)' == 'Core' ">dotnet run -p $(RootDir)Clojure.Main --framework $(TestTargetFramework) -c $(Configuration) --</clji>		
 	
 	<ClojureCompileBinDir>$(RootDir)Clojure.Compile\bin\$(Configuration)\$(TestTargetFramework)</ClojureCompileBinDir>
 	<cljc>Clojure.Compile.exe</cljc>


### PR DESCRIPTION
This patch makes a few changes to msbuild projects so that they can be built on *nix systems without much hassle. Tested on dotnet SDK + net5.0 & mono net461 on Alpine Linux.

Resolves issues discussed in
 - https://ask.clojure.org/index.php/10427/cannot-install-clojure-main-1-10-0-rc1-dotnet-tool
 - https://clojure.atlassian.net/browse/CLJCLR-111
 - https://clojure.atlassian.net/browse/CLJCLR-110

Before this patch, Clojure.Compiler.csproj didn't take *nix systems with mono into account, which caused the build to halt prematurely. This has been fixed by removing a dependency on xcopy, and running the compiler with mono when on *nix. build.proj will also check to see if the dotnet sdk msbuild is building for netcore 3.1+ and run Clojure.Main with `dotnet run` so tests can be run properly. See `MSBuildRuntimeType` property [in this docs page](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019) for more info on the platform check.

The only discrepancy I can find is in [Preparing a release](https://github.com/clojure/clojure-clr/blob/master/docs/Preparing-a-release.md) where it mentions `Clojure.Main.exe` for netcore 3.1+. My builds don't create this artifact, and I can't find it in the public RC1 nuget package either. Is this documentation out of date? If so, I wouldn't mind adding some clarification or updating the docs.

For reference, these build commands succeed on my system:

`dotnet msbuild build.proj -t:Test -p:TestTargetFramework=net5.0 -p:Configuration=Release`
`dotnet msbuild build.proj -t:TestGen -p:TestTargetFramework=net5.0 -p:Configuration=Release`
`dotnet msbuild build.proj -t:ZipAll -p:TestTargetFramework=net5.0 -p:Configuration=Release`
`dotnet msbuild build.proj -t:Test -p:TestTargetFramework=net461 -p:Runtime=Mono -p:Configuration=Release`
`dotnet msbuild build.proj -t:TestGen -p:TestTargetFramework=net461 -p:Runtime=Mono -p:Configuration=Release`
`dotnet msbuild build.proj -t:ZipAll -p:TestTargetFramework=net461 -p:Runtime=Mono -p:Configuration=Release`

I'm able to install the Clojure.Main dotnet tool from the generated nuget packages on net5.0

**I still need to test netcore3.1 after I get it re-installed :^)

System info:

```
% uname -a
Linux bbox 5.10.23-0-lts #1-Alpine SMP Mon, 15 Mar 2021 06:55:22 +0000 x86_64 Linux

% dotnet --info
.NET SDK (reflecting any global.json):
 Version:   5.0.202
 Commit:    db7cc87d51

Runtime Environment:
 OS Name:     alpine
 OS Version:  3.14
 OS Platform: Linux
 RID:         linux-musl-x64
 Base Path:   /home/john/.dotnet/sdk/5.0.202/

Host (useful for support):
  Version: 5.0.5
  Commit:  2f740adc14

.NET SDKs installed:
  5.0.202 [/home/john/.dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 5.0.5 [/home/john/.dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 5.0.5 [/home/john/.dotnet/shared/Microsoft.NETCore.App]

To install additional .NET runtimes or SDKs:
  https://aka.ms/dotnet-download

% mono --version
Mono JIT compiler version 6.12.0.122 (tarball Wed Apr  7 08:58:52 UTC 2021)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       normal
        Notifications: epoll
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug 
        Interpreter:   yes
        LLVM:          supported, not enabled.
        Suspend:       hybrid
        GC:            sgen (concurrent by default)
```
