### PR TITLE
Skip assembly if we can't get its types

### DIFF
--- a/Clojure/Clojure/Lib/RT.cs
+++ b/Clojure/Clojure/Lib/RT.cs
@@ -55,8 +55,11 @@ namespace clojure.lang
 
         static IEnumerable<Type> GetAllTypesInNamespace(string nspace)
         {
+            Func<Assembly, IEnumerable<Type>> getTypes = (Assembly a) => {
+                try { return a.GetTypes(); } catch (Exception) { return new Type[0]; }
+            };
             var q = AppDomain.CurrentDomain.GetAssemblies()
-                       .SelectMany(t => t.GetTypes())
+                       .SelectMany(t => getTypes(t))
                        .Where(t => (t.IsClass || t.IsInterface || t.IsValueType) &&
                                     t.Namespace == nspace &&
                                     t.IsPublic &&


### PR DESCRIPTION
When initializing, the ClojureCLR runtime (RT.cs) scans all loaded assemblies looking for types in the "System" namespace. If ClojureCLR is accessed from another program, e.g. in development of a plugin, it can encounter assemblies for which attempting to get the types from that assembly will throw an exception. This change simply swallows those exceptions allowing the process to complete. 